### PR TITLE
Correct API base url for RTD

### DIFF
--- a/jaraco/develop/rtd.py
+++ b/jaraco/develop/rtd.py
@@ -4,7 +4,7 @@ import keyring
 from requests_toolbelt import sessions
 
 
-url = 'https://api.readthedocs.org/'
+url = 'https://readthedocs.org/'
 
 
 @functools.lru_cache()


### PR DESCRIPTION
All [RTD docs](https://docs.readthedocs.io/en/stable/api/v3.html#projects-list) use https://readthedocs.org as the base URL. Requests to https://api.readthedocs.org/ are unsuccessful, often with the "301 Moved Permanently" status. This PR fixes that bug.

Remember to migrate the keyring key!