### PR TITLE
Sync GitHub metadata

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,7 +8,7 @@ def pytest_configure():
     os.environ['GITHUB_TOKEN'] = 'abc'
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def git_url_substitutions(fake_process):
     cmd = ['git', 'config', '--get-regexp', r'url\..*\.insteadof']
     stdout = textwrap.dedent(

--- a/jaraco/develop/add-github-secret.py
+++ b/jaraco/develop/add-github-secret.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import autocommand
 
 from . import github
 
 
 @autocommand.autocommand(__name__)
-def run(name, value, project: github.Repo = github.Repo.detect()):
-    project.add_secret(name, value)
+def run(name, value, project: github.Repo | None = None):
+    (project or github.Repo.detect()).add_secret(name, value)

--- a/jaraco/develop/add-github-secrets.py
+++ b/jaraco/develop/add-github-secrets.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import autocommand
 import keyring
 import getpass
@@ -32,7 +34,8 @@ secret_sources = {
 
 
 @autocommand.autocommand(__name__)
-def run(project: github.Repo = github.Repo.detect()):
+def run(project: github.Repo | None = None):
+    project = project or github.Repo.detect()
     for name in project.find_needed_secrets():
         source = secret_sources[name]
         value = keyring.get_password(**source)

--- a/jaraco/develop/create-github-release.py
+++ b/jaraco/develop/create-github-release.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import autocommand
 
 from . import github
@@ -5,6 +7,6 @@ from . import repo
 
 
 @autocommand.autocommand(__name__)
-def run(project: github.Repo = github.Repo.detect()):
+def run(project: github.Repo | None = None):
     md = repo.get_project_metadata()
-    project.create_release(tag=f'v{md.version}')
+    (project or github.Repo.detect()).create_release(tag=f'v{md.version}')

--- a/jaraco/develop/git.py
+++ b/jaraco/develop/git.py
@@ -131,6 +131,13 @@ class Project(str):
         topics = topics_assigned and filter(None, topics_assigned.group(1).split(','))
         return cls(match.name, tags=tags, topics=list(map(str.strip, topics or ())))
 
+    @property
+    def rtd_slug(self):
+        return self.replace('.', '').replace('_', '-')
+
+    @property
+    def rtd_url(self):
+        return f'https://{self.rtd_slug}.readthedocs.io/'
 
 
 def resolve(name):

--- a/jaraco/develop/git.py
+++ b/jaraco/develop/git.py
@@ -16,7 +16,6 @@ from more_itertools import flatten
 
 class URLScheme:
     """
-    >>> getfixture('git_url_substitutions')
     >>> scheme = URLScheme.lookup('gh://foo/bar')
     >>> scheme.resolve('gh://foo/bar')
     'https://github.com/foo/bar'

--- a/jaraco/develop/git.py
+++ b/jaraco/develop/git.py
@@ -141,10 +141,10 @@ class Project(str):
     @classmethod
     def from_path(self, path):
         from . import github
-        local = f'{github.username()}{posixpath.sep}'
+        local = f'{github.username()}/'
         if path.startswith(local):
             return self(path.removeprefix(local))
-        return self(posixpath.sep + path.removeprefix(posixpath.sep))
+        return self(f'/{path.removeprefix("/")}')
 
     @property
     def rtd_slug(self):

--- a/jaraco/develop/git.py
+++ b/jaraco/develop/git.py
@@ -5,6 +5,7 @@ import pathlib
 import posixpath
 import re
 import subprocess
+import sys
 import types
 import urllib.parse
 
@@ -114,9 +115,18 @@ class Project(str):
     """
 
     pattern = re.compile(r'(?P<name>\S+)\s*(?P<rest>.*)$')
+    cache = {}
 
-    def __new__(self, value, **kwargs):
-        return super().__new__(self, value)
+    def __new__(cls, value, **kwargs):
+        try:
+            return cls.cache[value]
+        except KeyError:
+            # Down-cast to a string early.
+            value = str(value)
+            sys.intern(value)  # :)
+            new = super().__new__(cls, value)
+            cls.cache[new] = new
+            return new
 
     def __init__(self, value, **kwargs):
         vars(self).update({'tags': [], 'topics': [], **kwargs})

--- a/jaraco/develop/git.py
+++ b/jaraco/develop/git.py
@@ -148,7 +148,7 @@ class Project(str):
 
     @property
     def rtd_slug(self):
-        return self.replace('.', '').replace('_', '-')
+        return posixpath.basename(self).replace('.', '').replace('_', '-')
 
     @property
     def rtd_url(self):

--- a/jaraco/develop/git.py
+++ b/jaraco/develop/git.py
@@ -120,17 +120,10 @@ class Project(str):
 
     pattern = re.compile(r'(?P<name>\S+)\s*(?P<rest>.*)$')
     tags: list[str] = []
-    cache: dict[str, Project] = {}
 
+    @functools.lru_cache
     def __new__(cls, value, **kwargs):
-        # Down-cast to a string early.
-        value = sys.intern(str(value))
-        try:
-            return cls.cache[value]
-        except KeyError:
-            new = super().__new__(cls, value)
-            cls.cache[new] = new
-            return new
+        return super().__new__(cls, value)
 
     def __init__(self, value, **kwargs):
         vars(self).update({'topics': [], **kwargs})

--- a/jaraco/develop/git.py
+++ b/jaraco/develop/git.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import contextlib
 import functools
 import os
@@ -114,7 +115,7 @@ class Project(str):
     """
 
     pattern = re.compile(r'(?P<name>\S+)\s*(?P<rest>.*)$')
-    cache = {}
+    cache: dict[str, Project] = {}
 
     def __new__(cls, value, **kwargs):
         # Down-cast to a string early.

--- a/jaraco/develop/git.py
+++ b/jaraco/develop/git.py
@@ -140,6 +140,12 @@ class Project(str):
 
     @classmethod
     def from_path(self, path):
+        """
+        >>> Project.from_path('pypa/setuptools')
+        '/pypa/setuptools'
+        >>> Project.from_path('jaraco/jaraco.functools')
+        'jaraco.functools'
+        """
         from . import github
         local = f'{github.username()}/'
         if path.startswith(local):
@@ -148,10 +154,22 @@ class Project(str):
 
     @property
     def rtd_slug(self):
+        """
+        >>> Project('jaraco.functools').rtd_slug
+        'jaracofunctools'
+        >>> Project('/pypa/setuptools_scm').rtd_slug
+        'setuptools-scm'
+        """
         return posixpath.basename(self).replace('.', '').replace('_', '-')
 
     @property
     def rtd_url(self):
+        """
+        >>> Project('jaraco.functools').rtd_url
+        'https://jaracofunctools.readthedocs.io/'
+        >>> Project('/pypa/setuptools_scm').rtd_url
+        'https://setuptools-scm.readthedocs.io/'
+        """
         return f'https://{self.rtd_slug}.readthedocs.io/'
 
 

--- a/jaraco/develop/git.py
+++ b/jaraco/develop/git.py
@@ -161,6 +161,16 @@ def resolve(name):
     return default.join(name)
 
 
+def resolve_repo_name(name):
+    """
+    >>> resolve_repo_name('keyring')
+    'jaraco/keyring'
+    >>> resolve_repo_name('/pypa/setuptools')
+    'pypa/setuptools'
+    """
+    return resolve(name).path.removeprefix(posixpath.sep)
+
+
 def target_for_root(project, root: path.Path = path.Path()):
     """
     Append the prefix of the resolved project name to the target

--- a/jaraco/develop/git.py
+++ b/jaraco/develop/git.py
@@ -106,11 +106,13 @@ class URL(str):
 
 class Project(str):
     """
-    >>> p = Project.parse('foo-project [tag1] [tag2]')
+    >>> p = Project.parse('foo-project [tag1] [tag2] (zero defect, coherent software)')
     >>> p
     'foo-project'
     >>> p.tags
     ['tag1', 'tag2']
+    >>> p.topics
+    ['zero defect', 'coherent software']
     """
 
     pattern = re.compile(r'(?P<name>\S+)\s*(?P<rest>.*)$')
@@ -124,8 +126,11 @@ class Project(str):
     @classmethod
     def parse(cls, line):
         match = types.SimpleNamespace(**cls.pattern.match(line).groupdict())
-        tags = list(re.findall(r'\[(.*?)\]', match.rest))
-        return cls(match.name, tags=tags)
+        tags = list(re.findall(r'\[(.*?)\]', rest := match.rest.rstrip()))
+        topics_assigned = re.match(r'[^\(\)]*\((.+)\)$', rest)
+        topics = topics_assigned and filter(None, topics_assigned.group(1).split(','))
+        return cls(match.name, tags=tags, topics=list(map(str.strip, topics or ())))
+
 
 
 def resolve(name):

--- a/jaraco/develop/git.py
+++ b/jaraco/develop/git.py
@@ -118,12 +118,11 @@ class Project(str):
     cache = {}
 
     def __new__(cls, value, **kwargs):
+        # Down-cast to a string early.
+        value = sys.intern(str(value))
         try:
             return cls.cache[value]
         except KeyError:
-            # Down-cast to a string early.
-            value = str(value)
-            sys.intern(value)  # :)
             new = super().__new__(cls, value)
             cls.cache[new] = new
             return new

--- a/jaraco/develop/git.py
+++ b/jaraco/develop/git.py
@@ -128,8 +128,8 @@ class Project(str):
         match = types.SimpleNamespace(**cls.pattern.match(line).groupdict())
         tags = list(re.findall(r'\[(.*?)\]', rest := match.rest.rstrip()))
         topics_assigned = re.match(r'[^\(\)]*\((.+)\)$', rest)
-        topics = topics_assigned and filter(None, topics_assigned.group(1).split(','))
-        return cls(match.name, tags=tags, topics=list(map(str.strip, topics or ())))
+        topics = topics_assigned and map(str.strip, topics_assigned.group(1).split(','))
+        return cls(match.name, tags=tags, topics=list(filter(None, topics or ())))
 
     @property
     def rtd_slug(self):

--- a/jaraco/develop/git.py
+++ b/jaraco/develop/git.py
@@ -119,7 +119,7 @@ class Project(str):
         return super().__new__(self, value)
 
     def __init__(self, value, **kwargs):
-        vars(self).update(kwargs)
+        vars(self).update({'tags': [], 'topics': [], **kwargs})
 
     @classmethod
     def parse(cls, line):

--- a/jaraco/develop/git.py
+++ b/jaraco/develop/git.py
@@ -139,6 +139,14 @@ class Project(str):
         topics = topics_assigned and map(str.strip, topics_assigned.group(1).split(','))
         return cls(match.name, tags=tags, topics=list(filter(None, topics or ())))
 
+    @classmethod
+    def from_path(self, path):
+        from . import github
+        local = f'{github.username()}{posixpath.sep}'
+        if path.startswith(local):
+            return self(path.removeprefix(local))
+        return self(posixpath.sep + path.removeprefix(posixpath.sep))
+
     @property
     def rtd_slug(self):
         return self.replace('.', '').replace('_', '-')

--- a/jaraco/develop/git.py
+++ b/jaraco/develop/git.py
@@ -12,8 +12,6 @@ import requests
 import path
 from more_itertools import flatten
 
-from . import github
-
 
 class URLScheme:
     """
@@ -148,6 +146,7 @@ def resolve(name):
     >>> 'gh://pmxbot/pmxbot.nsfw' in projects
     True
     """
+    from . import github
     default = URL(f'https://github.com/{github.username()}/')
     return default.join(name)
 

--- a/jaraco/develop/git.py
+++ b/jaraco/develop/git.py
@@ -213,7 +213,8 @@ def checkout_missing(project, root):
 
 @contextlib.contextmanager
 def temp_checkout(project, **kwargs):
+    kwargs.setdefault("depth", 50)
     with path.TempDir() as dir:
-        repo = checkout(project, dir, depth=50, **kwargs)
+        repo = checkout(project, dir, **kwargs)
         with repo:
             yield

--- a/jaraco/develop/github.py
+++ b/jaraco/develop/github.py
@@ -94,6 +94,45 @@ class Repo(str):
             )
         )
 
+    def get_metadata(self):
+        """
+        Get repository metadata.
+
+        https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#get-a-repository
+
+        >>> Repo('jaraco/pip-run').get_metadata()['description']
+        'pip-run - dynamic dependency loader for Python'
+        """
+        resp = self.session.get(self)
+        resp.raise_for_status()
+        return resp.json()
+
+    def update_metadata(self, **kwargs):
+        """
+        Update repository metadata (without overwriting existing keys).
+
+        Some useful metadata keys:
+        - name (str)
+        - description (str)
+        - homepage (str)
+        - visibility ("public" or "private")
+        - has_issues (bool)
+        - default_branch (str)
+        - archived (bool)
+        - allow_forking (bool)
+
+        See docs for all of them: https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#update-a-repository--parameters
+
+        >>> Repo('jaraco/dead-parrot').update(
+        ...     description="It's no more",
+        ...     homepage='https://youtu.be/4vuW6tQ0218',
+        ... )
+        <Response [200]>
+        """
+        resp = self.session.patch(self, json=kwargs)
+        resp.raise_for_status()
+        return resp
+
 
 def username():
     return os.environ.get('GITHUB_USERNAME') or getpass.getuser()

--- a/jaraco/develop/github.py
+++ b/jaraco/develop/github.py
@@ -133,6 +133,27 @@ class Repo(str):
         resp.raise_for_status()
         return resp
 
+    def get_topics(self):
+        """
+        Get topics for the repository.
+
+        >>> Repo('jaraco/irc').get_topics()
+        ['irc', 'python']
+        """
+        resp = self.session.get(self + '/topics')
+        resp.raise_for_status()
+        return resp.json()['names']
+
+    def set_topics(self, *topics):
+        """Completely replace the existing topics with only the given ones."""
+        resp = self.session.put(self + '/topics', json=dict(names=topics))
+        resp.raise_for_status()
+        return resp
+
+    def add_topics(self, *topics):
+        """Add new topics to the repository, without removing existing ones."""
+        return self.set_topics(*self.get_topics(), *topics)
+
 
 def username():
     return os.environ.get('GITHUB_USERNAME') or getpass.getuser()

--- a/jaraco/develop/github.py
+++ b/jaraco/develop/github.py
@@ -146,7 +146,8 @@ class Repo(str):
 
     def set_topics(self, *topics):
         """Completely replace the existing topics with only the given ones."""
-        resp = self.session.put(self + '/topics', json=dict(names=topics))
+        names = list(map(str.lower, (topic.replace(' ', '-') for topic in topics)))
+        resp = self.session.put(self + '/topics', json=dict(names=names))
         resp.raise_for_status()
         return resp
 

--- a/jaraco/develop/github.py
+++ b/jaraco/develop/github.py
@@ -4,6 +4,7 @@ import base64
 import functools
 import re
 import pathlib
+import posixpath
 import itertools
 
 import keyring
@@ -11,6 +12,7 @@ import nacl.public
 import nacl.encoding
 from requests_toolbelt import sessions
 
+from . import git
 from . import repo
 
 
@@ -42,8 +44,14 @@ class Repo(str):
         return token
 
     @classmethod
-    def detect(cls):
-        return cls(repo.get_project_metadata().project)
+    def from_project(cls, project, *, upstream=False):
+        if 'fork' in project.tags and not upstream:
+            return cls(posixpath.sep.join((username(), posixpath.basename(project))))
+        return cls(git.resolve(project).path[1:])
+
+    @classmethod
+    def detect(cls, *, upstream=False):
+        return cls.from_project(repo.get_project_metadata().project, upstream=upstream)
 
     @functools.lru_cache()
     def get_public_key(self):

--- a/jaraco/develop/github.py
+++ b/jaraco/develop/github.py
@@ -136,7 +136,7 @@ class Repo(str):
 
         See docs for all of them: https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#update-a-repository--parameters
 
-        >>> Repo('jaraco/dead-parrot').update_metadata(
+        >>> Repo('jaraco/dead-parrot').update_metadata(  # doctest: +SKIP
         ...     description="It's no more",
         ...     homepage='https://youtu.be/4vuW6tQ0218',
         ... )

--- a/jaraco/develop/github.py
+++ b/jaraco/develop/github.py
@@ -55,7 +55,7 @@ class Repo(str):
 
     @classmethod
     def detect(cls, *, upstream=False):
-        project = git.Project(repo.get_project_metadata().project)
+        project = git.Project.from_path(repo.get_project_metadata().project)
         return cls.from_project(project, upstream=upstream)
 
     @functools.lru_cache()

--- a/jaraco/develop/github.py
+++ b/jaraco/develop/github.py
@@ -24,6 +24,10 @@ class Repo(str):
     def __init__(self, name):
         self.session = self.get_session()
 
+    @property
+    def url(self):
+        return 'https://github.com/' + self
+
     @classmethod
     @functools.lru_cache()
     def get_session(cls):

--- a/jaraco/develop/github.py
+++ b/jaraco/develop/github.py
@@ -51,11 +51,12 @@ class Repo(str):
     def from_project(cls, project, *, upstream=False):
         if 'fork' in project.tags and not upstream:
             return cls(posixpath.sep.join((username(), posixpath.basename(project))))
-        return cls(git.resolve(project).path[1:])
+        return cls(git.resolve_repo_name(project))
 
     @classmethod
     def detect(cls, *, upstream=False):
-        return cls.from_project(repo.get_project_metadata().project, upstream=upstream)
+        project = git.Project(repo.get_project_metadata().project)
+        return cls.from_project(project, upstream=upstream)
 
     @functools.lru_cache()
     def get_public_key(self):
@@ -135,7 +136,7 @@ class Repo(str):
 
         See docs for all of them: https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#update-a-repository--parameters
 
-        >>> Repo('jaraco/dead-parrot').update(
+        >>> Repo('jaraco/dead-parrot').update_metadata(
         ...     description="It's no more",
         ...     homepage='https://youtu.be/4vuW6tQ0218',
         ... )

--- a/jaraco/develop/github.py
+++ b/jaraco/develop/github.py
@@ -26,7 +26,7 @@ class Repo(str):
 
     @property
     def url(self):
-        return 'https://github.com/' + self
+        return f'https://github.com/{self}'
 
     @classmethod
     @functools.lru_cache()
@@ -152,14 +152,14 @@ class Repo(str):
         >>> Repo('jaraco/irc').get_topics()
         ['irc', 'python']
         """
-        resp = self.session.get(self + '/topics')
+        resp = self.session.get(f'{self}/topics')
         resp.raise_for_status()
         return resp.json()['names']
 
     def set_topics(self, *topics):
         """Completely replace the existing topics with only the given ones."""
         names = list(map(str.lower, (topic.replace(' ', '-') for topic in topics)))
-        resp = self.session.put(self + '/topics', json=dict(names=names))
+        resp = self.session.put(f'{self}/topics', json=dict(names=names))
         resp.raise_for_status()
         return resp
 

--- a/jaraco/develop/repo.py
+++ b/jaraco/develop/repo.py
@@ -12,6 +12,7 @@ def get_project_metadata():
     version = _md['Version']
     project = urllib.parse.urlparse(url).path.strip('/')
     name = _md['Name']
+    summary = _md.get('Summary')
     return types.SimpleNamespace(**locals())
 
 

--- a/jaraco/develop/rtd.py
+++ b/jaraco/develop/rtd.py
@@ -15,6 +15,12 @@ def session():
     return session
 
 
+def rtd_exists(project):
+    return session().head(f'projects/{project.rtd_slug}/').ok
+
+
 def enable_pr_build(project):
-    slug = project.replace('.', '').replace('_', '-')
-    session().patch(f'projects/{slug}/', data=dict(external_builds_enabled=True))
+    session().patch(
+        f'projects/{project.rtd_slug}/',
+        data=dict(external_builds_enabled=True),
+    )

--- a/jaraco/develop/rtd.py
+++ b/jaraco/develop/rtd.py
@@ -4,7 +4,7 @@ import keyring
 from requests_toolbelt import sessions
 
 
-url = 'https://api.readthedocs.org/'
+url = 'https://readthedocs.org/'
 
 
 @functools.lru_cache()

--- a/jaraco/develop/sync-github.py
+++ b/jaraco/develop/sync-github.py
@@ -1,0 +1,44 @@
+"""
+Sync GitHub metadata repo across all projects.
+
+Metadata includes description, homepage (RTD docs if available) and topics.
+"""
+
+import autocommand
+
+from . import filters
+from . import git
+from . import github
+from . import repo
+from . import rtd
+
+
+@autocommand.autocommand(__name__)
+def main(
+    keyword: filters.Keyword = None,  # type: ignore
+    tag: filters.Tag = None,  # type: ignore
+):
+    for project in filter(tag, filter(keyword, git.projects())):
+        with git.temp_checkout(project, depth=1):
+            md = repo.get_project_metadata()
+            gh = github.Repo.from_project(project)
+            gh_metadata = gh.get_metadata()
+            # https://github.com/jaraco/pytest-perf/issues/10#issuecomment-1913669951
+            # homepage = md.homepage
+            homepage = (
+                gh_metadata.get('homepage')
+                or (project.rtd_url if rtd.rtd_exists(project) else None)
+            )
+            description = gh_metadata.get('description') or md.summary
+            print(f'\n[Metadata for {gh}]')
+            print('Homepage:', homepage)
+            print('Description:', description)
+            print('Topics:', ', '.join(project.topics))
+            gh.update_metadata(
+                homepage=homepage,
+                description=description,
+            )
+            print('\nUpdated metadata.')
+            gh.add_topics(*project.topics)
+            print('Added topics.\n')
+            print(gh.url)


### PR DESCRIPTION
Please see also #9 and jaraco/dotfiles#2.
Closes jaraco/pytest-perf#10, closes #8.

## Overview
- The new `sync-github` routine now syncs these data with GitHub repos of all downstream projects:
  - description (from the PEP 566 summary field),
  - homepage (a link to RTD),
  - GitHub topics (set by the project list, see next point).
  
  Description and homepage are _not_ overwritten if they are already present. This is to ensure that manual changes to the repository's metadata are honored. If the project's description or homepage are changed, either that change must be applied manually to the repo or the description or homepage must be removed from the repository's metadata entirely before the next periodic synchronization (which is unlikely, since it is faster to apply the change by hand).
- GitHub topics can now be set in the project list, after tags, in parentheses, separated by commas. Example:
  https://github.com/bswck/dotfiles/blob/0ea5638263a9a98db3cd39001a684184ac9da8a5/projects.txt#L139
  Topics won't overwrite topics you add through GitHub itself. You can technically call `Repo.set_topics()` that would replace the repository's topics entirely, but `Repo.add_topics()` is the default policy. Topics in the project list can have spaces and they will be implicitly converted to dashes, and whole topics lower-cased, as required by the GitHub API.
- The `sync-github` routine will try to find an existing RTD documentation, basing on the foregoing assumption that the project RTD slug is identical with the project name (after removing dots and kebabifying).
- Fetch depth can now be customized in `temp_checkout()`. `sync-github` uses the depth of 1.
- `Repo` objects now work well with forks: imagine we're in `/pypa/setuptools [fork]`; `github.Repo.detect()` will correctly create `github.Repo(f"{github.username()}/setuptools")` and `github.Repo.detect(upstream=True)` will create `github.Repo("pypa/setuptools")`. Note: we build on the assumption that forks belong to the user, not one of their organizations.

> [!Important]
> **Known limitation**: if there are more than 30 topics, they are consumed. I didn't implement handling the pagination as I assumed there won't be a necessity of having more than 20 topics. Let me know if I should implement that regardless.
