### PR TITLE
Run tests with isolated home and configured git

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,7 +9,7 @@ def pytest_configure():
     os.environ['GITHUB_TOKEN'] = 'abc'
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def git_url_substitutions(fake_process):
     cmd = ['git', 'config', '--get-regexp', r'url\..*\.insteadof']
     stdout = textwrap.dedent(

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,5 @@
 import os
-import textwrap
+import subprocess
 import urllib.request
 
 import pytest
@@ -10,16 +10,17 @@ def pytest_configure():
 
 
 @pytest.fixture(autouse=True)
-def git_url_substitutions(fake_process):
-    cmd = ['git', 'config', '--get-regexp', r'url\..*\.insteadof']
-    stdout = textwrap.dedent(
-        """
-        url.https://github.com/.insteadof gh://
-        url.https://gist.github.com/.insteadof gist://
-        """.lstrip()
-    )
-
-    fake_process.register(cmd, stdout=stdout)
+def git_url_substitutions(tmp_home_dir):
+    """
+    Configure Git to have substitutions for gh:// and gist://
+    """
+    subs = {
+        'gh': 'https://github.com/',
+        'gist': 'https://gist.github.com/',
+    }
+    for scheme, url in subs.items():
+        cmd = ['git', 'config', '--global', f'url.{url}.insteadof', f'{scheme}://']
+        subprocess.check_call(cmd)
 
 
 @pytest.fixture(autouse=True)

--- a/jaraco/develop/git.py
+++ b/jaraco/develop/git.py
@@ -64,7 +64,7 @@ class URLScheme:
     @functools.lru_cache()
     def load(cls):
         cmd = ['git', 'config', '--get-regexp', r'url\..*\.insteadof']
-        lines = subprocess.check_output(cmd, text=True)
+        lines = subprocess.check_output(cmd, text=True, encoding='utf-8')
         return set(map(cls.parse, lines.splitlines()))
 
     @classmethod

--- a/pytest.ini
+++ b/pytest.ini
@@ -20,6 +20,3 @@ filterwarnings=
 	ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:dateutil.tz.tz
 
 	## end upstream
-
-usefixtures =
-	tmp_home_dir

--- a/pytest.ini
+++ b/pytest.ini
@@ -20,3 +20,6 @@ filterwarnings=
 	ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:dateutil.tz.tz
 
 	## end upstream
+
+usefixtures =
+	tmp_home_dir

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ testing =
 	# local
 	pytest-subprocess
 	types-requests
+	pytest-home
 
 docs =
 	# upstream

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,6 @@ testing =
 	pytest-ruff >= 0.2.1
 
 	# local
-	pytest-subprocess
 	types-requests
 	pytest-home
 


### PR DESCRIPTION
- **Apply the tmp_home_dir fixture to ensure user's git config is not touched. Ref #14.**
- **Configure GitHub URL substitutions as an autouse fixture. Closes #14.**
- **Prefer configuring git to have the substitutions rather than mocking the effect.**
- **Fix EncodingWarning.**
