### PR TITLE
Add missing types-setuptools in type test and re-enable mypy test

### DIFF
--- a/jaraco/develop/compiler.py
+++ b/jaraco/develop/compiler.py
@@ -3,7 +3,7 @@ import mimetypes
 import shutil
 import tempfile
 
-from setuptools._distutils import ccompiler, sysconfig  # type: ignore[import-untyped]
+from setuptools._distutils import ccompiler, sysconfig
 
 from jaraco.ui.editor import EditableFile
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,11 +80,8 @@ type = [
 	"pytest-mypy",
 
 	# local
+	"types-setuptools",
 ]
 
 
 [tool.setuptools_scm]
-
-
-[tool.pytest-enabler.mypy]
-# Disabled due to jaraco/skeleton#143


### PR DESCRIPTION
Ref https://github.com/jaraco/skeleton/issues/143