### PR TITLE
Use common towncrier config shipped inside the project as resource file.

### DIFF
--- a/jaraco/develop/_towncrier.toml
+++ b/jaraco/develop/_towncrier.toml
@@ -1,0 +1,29 @@
+[tool.towncrier]
+title_format = "{version}"
+
+# Custom "deprecation" behaviour, references:
+# - https://github.com/jaraco/skeleton/issues/169
+# - https://github.com/twisted/towncrier/issues/704
+
+# Unfortunately default sections need to be redefined when customising:
+# https://towncrier.readthedocs.io/en/latest/configuration.html#custom-fragment-types
+
+[tool.towncrier.fragment.removal]
+name = "Removals and Breaking Changes"
+
+[tool.towncrier.fragment.feature]
+name = "Features"
+
+[tool.towncrier.fragment.deprecation]
+name = "Deprecations"
+
+[tool.towncrier.fragment.bugfix]
+name = "Bugfixes and Minor Changes"
+
+[tool.towncrier.fragment.doc]
+name = "Improved Documentation"
+showcontent = false
+
+[tool.towncrier.fragment.misc]
+name = "Miscellaneous and Internal Changes"
+showcontent = false

--- a/jaraco/develop/towncrier.py
+++ b/jaraco/develop/towncrier.py
@@ -1,4 +1,5 @@
 import collections
+import importlib.resources
 import pathlib
 import subprocess
 import sys
@@ -6,12 +7,15 @@ import sys
 from jaraco.vcs import repo
 from jaraco.versioning import semver
 
+_pkg = __package__ or "jaraco.develop"
+
 _release_bumps = collections.defaultdict(
     feature='minor',
     bugfix='patch',
     doc='minor',
     removal='major',
     misc='patch',
+    deprecation='minor',
 )
 """
 Map the towncrier default fragment types to semver bumps.
@@ -65,15 +69,21 @@ def get_version():
 
 
 def run(command, *args):
-    cmd = (
-        sys.executable,
-        '-m',
-        'towncrier',
-        command,
-        '--version',
-        semver(get_version()),
-    ) + args
-    subprocess.check_call(cmd)
+    config = importlib.resources.files(_pkg).joinpath("_towncrier.toml")
+    with importlib.resources.as_file(config) as config_file:
+        cmd = (
+            sys.executable,
+            '-m',
+            'towncrier',
+            command,
+            '--config',
+            config_file,
+            '--dir',
+            '.',  # for some reason `towncrier` attempts to infer from config_file
+            '--version',
+            semver(get_version()),
+        ) + args
+        subprocess.check_call(cmd)
 
 
 if __name__ == '__main__':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ test = [
 	# local
 	"types-requests",
 	"pytest-home",
+	"towncrier",
 ]
 
 doc = [

--- a/tests/test_towncrier.py
+++ b/tests/test_towncrier.py
@@ -1,0 +1,40 @@
+import pytest
+
+from jaraco.develop import towncrier
+from jaraco.versioning import semver
+
+
+@pytest.mark.parametrize(
+    ("file", "expected_version", "title", "show_content"),
+    [
+        ("1.removal.rst", "v1.0.0", "Removals and Breaking Changes", True),
+        ("2.feature.rst", "v0.1.0", "Features", True),
+        ("3.deprecation.rst", "v0.1.0", "Deprecations", True),
+        ("4.bugfix.rst", "v0.0.1", "Bugfixes", True),
+        ("5.doc.rst", "v0.1.0", "Documentation", False),
+        ("6.misc.rst", "v0.0.1", "Miscellaneous", False),
+    ],
+)
+def test_release_bumps(
+    monkeypatch, tmp_path, git_repo, file, expected_version, title, show_content
+):
+    monkeypatch.chdir(tmp_path)
+    git_repo.commit_tree({}, 'initial commit')
+    git_repo._invoke("tag", "v0.0.0")  # from jaraco.vcs.fixtures
+    newsfragments = tmp_path / "newsfragments"
+    newsfragments.mkdir()
+    (newsfragments / file).write_text("Lorem Ipsum", encoding="utf-8")
+
+    towncrier.check_changes()  # no exception
+    assert semver(towncrier.get_version()) == expected_version
+
+    news = tmp_path / "NEWS.rst"
+    towncrier.run("build", "--yes")
+    assert news.is_file()
+
+    content = news.read_text(encoding="utf-8")
+    assert expected_version in content
+    assert title in content
+    assert f"#{file[0]}" in content
+
+    assert show_content == ("Lorem Ipsum" in content)

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,2 +1,0 @@
-[tool.towncrier]
-title_format = "{version}"


### PR DESCRIPTION
This way we can fix jaraco/skeleton#169 without having to copy/paste the same boilerplate in several different projects

We can just keep a single configuration file in `jaraco/develop/_towncrier.toml` that will be shared with all consumers of `python -m jaraco.develop.towncrier`/`python -m jaraco.develop.finalize`.


The drawbacks of this approach are:

- Existing configs in the local project directory (`towncriar.toml` and `pyproject.toml`) will be ignored. All projects will use `jaraco/develop/_towncrier.toml`.

- The `--dir` and `--config` flags (possibly) cannot be passed to the `towncrier.run(*args)` function.
  This particular drawback can be worked around, for example, I can modify the implementation to only add the options if they are not already present in `args`. I haven't done that because I have the impression that no call passes these options for now.